### PR TITLE
Update documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -72,7 +72,7 @@
 ---
 company: "Company or Organization Name"
 description: "1 to 2 sentence description about apprenticeship by this company or organization."
-image: "/images/apprenticeships/company-name.jpeg"
+image: "company-name.jpeg"
 link: "https://company-website.com"
 location:
   - "London, UK"


### PR DESCRIPTION
I don't know when I did this, but it is unnecessary to add the image path to the markdown file. Only the filename and file extension are necessary.