### PR TITLE
Fix Microsoft Leap URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ This project exists thanks to all the people who contribute. [[Contribute](CONTR
 - [Michael Bonner](http://github.com/mdb1710)
 - [Aaron Clark](https://github.com/aaronclarkcodes)
 - [Ken Sparks](https://github.com/KenSparks-Dev)
+- [Larry Urrego](https://github.com/LaUrrego)

--- a/content/apprenticeships/microsoft-leap.md
+++ b/content/apprenticeships/microsoft-leap.md
@@ -2,7 +2,7 @@
 company: "Microsoft LEAP"
 description: "LEAP Engineering Acceleration Program (LEAP) is an immersive, 16-week program providing real-world experience through development and project management for individuals with non-traditional backgrounds or are returning to the workforce."
 image: "microsoft-leap.jpg"
-link: "http://industryexplorers.com"
+link: "https://www.microsoft.com/en-us/leap/"
 location:
   - "Redmond, WA"
 ---


### PR DESCRIPTION
Original link lead to https://industryexplorers.com/. It should be: https://www.microsoft.com/en-us/leap/
Link corrected and name added to Credits section of the README.md.
---

<!-- Thank you for contributing to this repo, it is much appreciated! 😊 -->

<!-- Before creating a PR, make sure to verify the following. -->

## ✅️ By submitting this PR, I have verified the following

- [X] Checked to see if a similar PR has already been opened 🤔️
- [X] Reviewed the contributing guidelines 🔍️
- [X] Added my name to the bottom of the list under the **Credits** section in the `README.md` with a link to my website or GitHub profile 👥️
