### PR TITLE
Update Barclays Apprenticeship link

### DIFF
--- a/content/apprenticeships/barclays.md
+++ b/content/apprenticeships/barclays.md
@@ -2,7 +2,7 @@
 company: "Barclays"
 description: "Kickstart your career in Technology with a Foundation or Higher Apprenticeship."
 image: "barclays.jpg"
-link: "https://joinus.barclays/eme/apprenticeships/"
+link: "https://search.jobs.barclays/apprenticeships"
 location:
   - "London, UK"
   - "Northampton, UK"


### PR DESCRIPTION
Barclays apprenticeship landing page link changed. Updated to "https://joinus.barclays/eme/apprenticeships/" to include all apprenticeships. 

---

<!-- Thank you for contributing to this repo, it is much appreciated! 😊 -->

<!-- Before creating a PR, make sure to verify the following. -->

## ✅️ By submitting this PR, I have verified the following

- [X] Checked to see if a similar PR has already been opened 🤔️
- [X] Reviewed the contributing guidelines 🔍️
- [X] Added my name to the bottom of the list under the **Credits** section in the `README.md` with a link to my website or GitHub profile 👥️
