### PR TITLE
Center apprenticeship cards on screens with width <=767 px

### DIFF
--- a/src/components/apprenticeship-card.tsx
+++ b/src/components/apprenticeship-card.tsx
@@ -12,7 +12,7 @@ export default function ApprenticeshipCard({ apprenticeship }: Props) {
       href={`/${apprenticeship.slug}`}
       className="block my-4 px-2 w-full md:w-1/2 lg:w-1/3"
     >
-      <div className="max-w-sm rounded overflow-hidden shadow-md hover:shadow-lg transition-shadow min-h-full bg-white">
+      <div className="mx-auto max-w-sm rounded overflow-hidden shadow-md hover:shadow-lg transition-shadow min-h-full bg-white">
         <div className="relative w-full h-48">
           <Image
             src={`/images/apprenticeships/${apprenticeship.image}`}


### PR DESCRIPTION
Center apprenticeship cards on screens with width <=767 px

Before:
<img width="1606" height="1512" alt="CleanShot 2026-04-09 at 19 02 56@2x" src="https://github.com/user-attachments/assets/50031a7e-709c-4662-af89-522693972be2" />

After: 
<img width="2532" height="1546" alt="CleanShot 2026-04-09 at 19 20 03@2x" src="https://github.com/user-attachments/assets/39d3a8c1-b996-4689-9651-605ff5d04ddf" />
https://github.com/user-attachments/assets/c6f50544-3918-4fba-9559-062513fada30
---

<!-- Thank you for contributing to this repo, it is much appreciated! 😊 -->

<!-- Before creating a PR, make sure to verify the following. -->

## ✅️ By submitting this PR, I have verified the following

- [] Checked to see if a similar PR has already been opened 🤔️
- [] Reviewed the contributing guidelines 🔍️
- [] Added my name to the bottom of the list under the **Credits** section in the `README.md` with a link to my website or GitHub profile 👥️
