### PR TITLE
Fix apprenticeship card images to display consistently (no stretching, aligned heights)

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -110,7 +110,7 @@ export default async function ApprenticeshipPage({ params }: PageProps) {
               src={`/images/apprenticeships/${apprenticeship.image}`}
               alt={`${apprenticeship.company} apprenticeship program`}
               fill
-              className="object-cover"
+              className="object-contain p-8 bg-white"
               sizes="(max-width: 768px) 100vw, 896px"
               priority
             />

--- a/src/components/apprenticeship-card.tsx
+++ b/src/components/apprenticeship-card.tsx
@@ -13,12 +13,12 @@ export default function ApprenticeshipCard({ apprenticeship }: Props) {
       className="block my-4 px-2 w-full md:w-1/2 lg:w-1/3"
     >
       <div className="mx-auto max-w-sm rounded overflow-hidden shadow-md hover:shadow-lg transition-shadow min-h-full bg-white">
-        <div className="relative w-full h-48">
+        <div className="relative w-full h-48 bg-white">
           <Image
             src={`/images/apprenticeships/${apprenticeship.image}`}
             alt={`${apprenticeship.company} apprenticeship program`}
             fill
-            className="object-cover"
+            className="object-contain p-6"
             sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
           />
         </div>


### PR DESCRIPTION
Fix apprenticeship card images to display consistently (no stretching, aligned heights)

Before:
<img width="2826" height="1596" alt="CleanShot 2026-05-02 at 12 18 24@2x" src="https://github.com/user-attachments/assets/bdf4bba4-f368-43fa-831b-dad47fb03b69" />


After:
<img width="2850" height="1672" alt="CleanShot 2026-05-02 at 12 18 09@2x" src="https://github.com/user-attachments/assets/0fcc7bbf-9718-403e-a3da-a5b97bc70b6c" />

---

<!-- Thank you for contributing to this repo, it is much appreciated! 😊 -->

<!-- Before creating a PR, make sure to verify the following. -->

## ✅️ By submitting this PR, I have verified the following

- [] Checked to see if a similar PR has already been opened 🤔️
- [] Reviewed the contributing guidelines 🔍️
- [] Added my name to the bottom of the list under the **Credits** section in the `README.md` with a link to my website or GitHub profile 👥️
